### PR TITLE
fix: return exit status code according to Flake8 result

### DIFF
--- a/flake8_cached/__main__.py
+++ b/flake8_cached/__main__.py
@@ -3,8 +3,10 @@
 """Package entry point."""
 
 
+import sys
+
 from flake8_cached.cli import main
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    sys.exit(main())

--- a/flake8_cached/cli.py
+++ b/flake8_cached/cli.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import flake8.checker as f8checker
 
@@ -38,8 +39,8 @@ checker.FileChecker = FileCheckerCached
 def main():
     from flake8.main import cli
 
-    cli.main()
+    return cli.main()
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
`flake8-cached` was always returning a status code 0 even when Flake8 found lint errors.

This PR return the status code from the `main()` function (from Flake8).